### PR TITLE
Added custom status to the orchestration grid, details and state

### DIFF
--- a/durablefunctionsmonitor.react/src/components/OrchestrationDetails.tsx
+++ b/durablefunctionsmonitor.react/src/components/OrchestrationDetails.tsx
@@ -172,7 +172,7 @@ export class OrchestrationDetails extends React.Component<{ state: Orchestration
 
         return (
             <Grid container className="grid-container">
-                <Grid item xs={12} sm={6} md={3} zeroMinWidth className="grid-item">
+                <Grid item xs={12} sm={6} md={2} zeroMinWidth className="grid-item">
                     <TextField
                         label="name"
                         value={details.name}
@@ -182,7 +182,7 @@ export class OrchestrationDetails extends React.Component<{ state: Orchestration
                         fullWidth
                     />
                 </Grid>
-                <Grid item xs={12} sm={6} md={3} zeroMinWidth className="grid-item">
+                <Grid item xs={12} sm={6} md={2} zeroMinWidth className="grid-item">
                     <TextField
                         label="createdTime"
                         value={details.createdTime}
@@ -192,7 +192,7 @@ export class OrchestrationDetails extends React.Component<{ state: Orchestration
                         fullWidth
                     />
                 </Grid>
-                <Grid item xs={12} sm={6} md={3} zeroMinWidth className="grid-item">
+                <Grid item xs={12} sm={6} md={2} zeroMinWidth className="grid-item">
                     <TextField
                         label="runtimeStatus"
                         value={details.runtimeStatus}
@@ -203,7 +203,17 @@ export class OrchestrationDetails extends React.Component<{ state: Orchestration
                         className={!!details.runtimeStatus ? "runtime-status-" + details.runtimeStatus.toLowerCase() : ""}
                     />
                 </Grid>
-                <Grid item xs={12} sm={6} md={3} zeroMinWidth className="grid-item">
+                <Grid item xs={12} sm={6} md={2} zeroMinWidth className="grid-item">
+                    <TextField
+                        label="customStatus"
+                        value={details.customStatus ? details.customStatus : ""}
+                        margin="normal"
+                        InputProps={{ readOnly: true }}
+                        variant="outlined"
+                        fullWidth
+                    />
+                </Grid>
+                <Grid item xs={12} sm={6} md={2} zeroMinWidth className="grid-item">
                     <TextField
                         label="lastUpdatedTime"
                         value={details.lastUpdatedTime}

--- a/durablefunctionsmonitor.react/src/components/Orchestrations.tsx
+++ b/durablefunctionsmonitor.react/src/components/Orchestrations.tsx
@@ -229,6 +229,9 @@ export class Orchestrations extends React.Component<{ state: OrchestrationsState
                                 <TableCell style={cellStyle}>
                                     {orchestration.runtimeStatus}
                                 </TableCell>
+                                <TableCell style={cellStyle}>
+                                    {orchestration.customStatus}
+                                </TableCell>
                                 <TableCell className="long-text-cell" style={cellStyle}>
                                     <InputBase
                                         className="long-text-cell-input"

--- a/durablefunctionsmonitor.react/src/states/DurableOrchestrationStatus.ts
+++ b/durablefunctionsmonitor.react/src/states/DurableOrchestrationStatus.ts
@@ -25,7 +25,7 @@ export class DurableOrchestrationStatus {
     name: string;
     runtimeStatus: string;
     input: any;
-    customStatus: string | null;
+    customStatus: string;
     output: any;
     createdTime: string;
     lastUpdatedTime: string;
@@ -39,6 +39,7 @@ export const DurableOrchestrationStatusFields = [
     'createdTime',
     'lastUpdatedTime',
     'runtimeStatus',
+    'customStatus',
     'input',
     'output'
 ];


### PR DESCRIPTION
I needed to filter orchestration by custom status so I added it to the grids and state.
It could be useful to someone else.

(I haven't pushed the wwwroot since it is generating a new precache-manifesto.js. I believe it's due to the latest typescript version that was automatically updated. 
But I can if you want me to.
)

Regards